### PR TITLE
feat: add Russian (phonetic) from linux layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Experimental - not tested:
 * Phags Pa [<sup>1</sup>](#note1)
 * Punjabi [<sup>1</sup>](#note1)
 * Russian (Typewriter)
+* Russian Phonetic Linux[<sup>3</sup>](#note3)
 * Russian Phonetic YaWert
 * Sakha [<sup>1</sup>](#note1)
 * Sami Extended Finland-Sweden
@@ -193,5 +194,37 @@ The following features are not available in android:
 * undo functionality (triggered by Z in level 4)
 * rotate key
 
+<sup id="note3">**3**</sup> Russian Phonetic Linux is taken from standard layouts available on Linux, it was modified slightly to add back some symbols that are replaced by Russian characters in the Base and Shift layers, to get to them use RightAlt and RightAlt+Shift respectively.
+
+Here are the notable modifications in relation to QWERTY
+* `SHIFT` + 3 => ё
+* `RALT` + 3 => #
+* `RALT` + `SHIFT` + 3 => №
+* `SHIFT` + 4 => Ё
+* `RALT` + 4 => $
+* `SHIFT` + 5 => ъ
+* `RALT` + 5 => %
+* `SHIFT` + 6 => Ъ
+* `RALT` + 6 => ^
+* = => ч
+* `SHIFT` + = (+) => Ч
+* `RALT` + = => =
+* `RALT` + `SHIFT` + = => +
+* [ => ш
+* `SHIFT` + [ => Ш
+* `RALT` + [ => [
+* `RALT` + `SHIFT` + [ => {
+* ] => щ
+* `SHIFT` + ] => Ш
+* `RALT` + ] => ]
+* `RALT` + `SHIFT` + ] => }
+* \` => ю
+* `SHIFT` + \` => Ю
+* `RALT` + \` => \`
+* `RALT` + `SHIFT` + \` => ~
+* \ => э
+* `SHIFT` + \ => Э
+* `RALT` + \ => \
+* `RALT` + `SHIFT` + \ => |
 
 If you found this useful, you may [buy me a drink](https://paypal.me/CalinDarie?locale.x=en_US)

--- a/app/src/main/res/raw/keyboard_layout_russian_phonetic_linux.kcm
+++ b/app/src/main/res/raw/keyboard_layout_russian_phonetic_linux.kcm
@@ -73,7 +73,8 @@ key 3 {
   base: '3'
   shift: '\u0451'
   capslock+shift: '\u0451'
-  ralt: '\u2116'
+  ralt: '\u0023'
+  ralt+shift: '\u2116'
 }
 
 key 4 {
@@ -81,6 +82,7 @@ key 4 {
   base: '4'
   shift: '\u0401'
   capslock+shift: '\u0401'
+  ralt: '\u0024'
 }
 
 key 5 {
@@ -88,6 +90,7 @@ key 5 {
   base: '5'
   shift: '\u044a'
   capslock+shift: '\u044a'
+  ralt: '\u0025'
 }
 
 key 6 {
@@ -95,6 +98,7 @@ key 6 {
   base: '6'
   shift: '\u042a'
   capslock+shift: '\u042a'
+  ralt: '\u005e'
 }
 
 key 7 {
@@ -138,6 +142,8 @@ key EQUALS {
   shift: '\u0427'
   capslock: '\u0427'
   capslock+shift: '\u0447'
+  ralt: '\u003d'
+  ralt+shift: '\u002b'
 }
 
 key Q {
@@ -227,6 +233,7 @@ key LEFT_BRACKET {
   shift: '\u0428'
   capslock: '\u0428'
   capslock+shift: '\u0448'
+  ralt: '\u005b'
 }
 
 key RIGHT_BRACKET {
@@ -235,6 +242,7 @@ key RIGHT_BRACKET {
   shift: '\u0429'
   capslock: '\u0429'
   capslock+shift: '\u0449'
+  ralt: '\u005d'
 }
 
 key A {
@@ -329,6 +337,8 @@ key GRAVE {
   shift: '\u042e'
   capslock: '\u042e'
   capslock+shift: '\u044e'
+  ralt: '\u0060'
+  ralt+shift: '\u007e'
 }
 
 key BACKSLASH {
@@ -337,6 +347,8 @@ key BACKSLASH {
   shift: '\u042d'
   capslock: '\u042d'
   capslock+shift: '\u044d'
+  ralt: '\u005c'
+  ralt+shift: '\u007c'
 }
 
 key Z {

--- a/app/src/main/res/raw/keyboard_layout_russian_phonetic_linux.kcm
+++ b/app/src/main/res/raw/keyboard_layout_russian_phonetic_linux.kcm
@@ -1,0 +1,439 @@
+# License: MIT
+
+# Russian Phonetic Linux
+type OVERLAY
+
+map key 2 1
+map key 3 2
+map key 4 3
+map key 5 4
+map key 6 5
+map key 7 6
+map key 8 7
+map key 9 8
+map key 10 9
+map key 11 0
+map key 12 MINUS
+map key 13 EQUALS
+map key 16 Q
+map key 17 W
+map key 18 E
+map key 19 R
+map key 20 T
+map key 21 Y
+map key 22 U
+map key 23 I
+map key 24 O
+map key 25 P
+map key 26 LEFT_BRACKET
+map key 27 RIGHT_BRACKET
+map key 30 A
+map key 31 S
+map key 32 D
+map key 33 F
+map key 34 G
+map key 35 H
+map key 36 J
+map key 37 K
+map key 38 L
+map key 39 SEMICOLON
+map key 40 APOSTROPHE
+map key 41 GRAVE
+map key 43 BACKSLASH
+map key 44 Z
+map key 45 X
+map key 46 C
+map key 47 V
+map key 48 B
+map key 49 N
+map key 50 M
+map key 51 COMMA
+map key 52 PERIOD
+map key 53 SLASH
+map key 57 SPACE
+map key 86 PLUS
+map key 83 NUMPAD_COMMA
+
+key 1 {
+  label: '1'
+  base: '1'
+  shift: '\u0021'
+  capslock+shift: '\u0021'
+}
+
+key 2 {
+  label: '2'
+  base: '2'
+  shift: '\u044a'
+  capslock+shift: '\u044a'
+}
+
+key 3 {
+  label: '3'
+  base: '3'
+  shift: '\u0451'
+  capslock+shift: '\u0451'
+  ralt: '\u2116'
+}
+
+key 4 {
+  label: '4'
+  base: '4'
+  shift: '\u0401'
+  capslock+shift: '\u0401'
+}
+
+key 5 {
+  label: '5'
+  base: '5'
+  shift: '\u044a'
+  capslock+shift: '\u044a'
+}
+
+key 6 {
+  label: '6'
+  base: '6'
+  shift: '\u042a'
+  capslock+shift: '\u042a'
+}
+
+key 7 {
+  label: '7'
+  base: '7'
+  shift: '\u0026'
+  capslock+shift: '\u0026'
+}
+
+key 8 {
+  label: '8'
+  base: '8'
+  shift: '\u002a'
+  capslock+shift: '\u002a'
+}
+
+key 9 {
+  label: '9'
+  base: '9'
+  shift: '\u0028'
+  capslock+shift: '\u0028'
+}
+
+key 0 {
+  label: '0'
+  base: '0'
+  shift: '\u0029'
+  capslock+shift: '\u0029'
+}
+
+key MINUS {
+  label: '\u002d'
+  base: '\u002d'
+  shift: '\u005f'
+  capslock+shift: '\u005f'
+}
+
+key EQUALS {
+  label: '\u003d'
+  base: '\u0447'
+  shift: '\u0427'
+  capslock: '\u0427'
+  capslock+shift: '\u0447'
+}
+
+key Q {
+  label: '\u044f'
+  base: '\u044f'
+  shift: '\u042f'
+  capslock: '\u042f'
+  capslock+shift: '\u044f'
+}
+
+key W {
+  label: '\u0432'
+  base: '\u0432'
+  shift: '\u0412'
+  capslock: '\u0412'
+  capslock+shift: '\u0432'
+}
+
+key E {
+  label: '\u0435'
+  base: '\u0435'
+  shift: '\u0415'
+  capslock: '\u0415'
+  capslock+shift: '\u0435'
+  ralt: '\u20ac'
+}
+
+key R {
+  label: '\u0440'
+  base: '\u0440'
+  shift: '\u0420'
+  capslock: '\u0420'
+  capslock+shift: '\u0440'
+}
+
+key T {
+  label: '\u0442'
+  base: '\u0442'
+  shift: '\u0422'
+  capslock: '\u0422'
+  capslock+shift: '\u0442'
+}
+
+key Y {
+  label: '\u044b'
+  base: '\u044b'
+  shift: '\u042b'
+  capslock: '\u042b'
+  capslock+shift: '\u044b'
+}
+
+key U {
+  label: '\u0443'
+  base: '\u0443'
+  shift: '\u0423'
+  capslock: '\u0423'
+  capslock+shift: '\u0443'
+}
+
+key I {
+  label: '\u0438'
+  base: '\u0438'
+  shift: '\u0418'
+  capslock: '\u0418'
+  capslock+shift: '\u0438'
+}
+
+key O {
+  label: '\u043e'
+  base: '\u043e'
+  shift: '\u041e'
+  capslock: '\u041e'
+  capslock+shift: '\u043e'
+}
+
+key P {
+  label: '\u043f'
+  base: '\u043f'
+  shift: '\u041f'
+  capslock: '\u041f'
+  capslock+shift: '\u043f'
+}
+
+key LEFT_BRACKET {
+  label: '\u0448'
+  base: '\u0448'
+  shift: '\u0428'
+  capslock: '\u0428'
+  capslock+shift: '\u0448'
+}
+
+key RIGHT_BRACKET {
+  label: '\u0449'
+  base: '\u0449'
+  shift: '\u0429'
+  capslock: '\u0429'
+  capslock+shift: '\u0449'
+}
+
+key A {
+  label: '\u0430'
+  base: '\u0430'
+  shift: '\u0410'
+  capslock: '\u0410'
+  capslock+shift: '\u0430'
+}
+
+key S {
+  label: '\u0441'
+  base: '\u0441'
+  shift: '\u0421'
+  capslock: '\u0421'
+  capslock+shift: '\u0441'
+}
+
+key D {
+  label: '\u0434'
+  base: '\u0434'
+  shift: '\u0414'
+  capslock: '\u0414'
+  capslock+shift: '\u0434'
+}
+
+key F {
+  label: '\u0444'
+  base: '\u0444'
+  shift: '\u0424'
+  capslock: '\u0424'
+  capslock+shift: '\u0444'
+}
+
+key G {
+  label: '\u0433'
+  base: '\u0433'
+  shift: '\u0413'
+  capslock: '\u0413'
+  capslock+shift: '\u0433'
+}
+
+key H {
+  label: '\u0445'
+  base: '\u0445'
+  shift: '\u0425'
+  capslock: '\u0425'
+  capslock+shift: '\u0445'
+}
+
+key J {
+  label: '\u0439'
+  base: '\u0439'
+  shift: '\u0419'
+  capslock: '\u0419'
+  capslock+shift: '\u0439'
+}
+
+key K {
+  label: '\u043a'
+  base: '\u043a'
+  shift: '\u041a'
+  capslock: '\u041a'
+  capslock+shift: '\u043a'
+}
+
+key L {
+  label: '\u043b'
+  base: '\u043b'
+  shift: '\u041b'
+  capslock: '\u041b'
+  capslock+shift: '\u043b'
+}
+
+key SEMICOLON {
+  label: '\u003b'
+  base: '\u003b'
+  shift: '\u003a'
+  capslock+shift: '\u003a'
+}
+
+key APOSTROPHE {
+  label: '\u0027'
+  base: '\u0027'
+  shift: '\u0022'
+  capslock+shift: '\u0022'
+}
+
+key GRAVE {
+  label: '\u044e'
+  base: '\u044e'
+  shift: '\u042e'
+  capslock: '\u042e'
+  capslock+shift: '\u044e'
+}
+
+key BACKSLASH {
+  label: '\u044d'
+  base: '\u044d'
+  shift: '\u042d'
+  capslock: '\u042d'
+  capslock+shift: '\u044d'
+}
+
+key Z {
+  label: '\u0437'
+  base: '\u0437'
+  shift: '\u0417'
+  capslock: '\u0417'
+  capslock+shift: '\u0437'
+}
+
+key X {
+  label: '\u044c'
+  base: '\u044c'
+  shift: '\u042c'
+  capslock: '\u042c'
+  capslock+shift: '\u044c'
+}
+
+key C {
+  label: '\u0446'
+  base: '\u0446'
+  shift: '\u0426'
+  capslock: '\u0426'
+  capslock+shift: '\u0446'
+}
+
+key V {
+  label: '\u0436'
+  base: '\u0436'
+  shift: '\u0416'
+  capslock: '\u0416'
+  capslock+shift: '\u0436'
+}
+
+key B {
+  label: '\u0431'
+  base: '\u0431'
+  shift: '\u0411'
+  capslock: '\u0411'
+  capslock+shift: '\u0431'
+}
+
+key N {
+  label: '\u043d'
+  base: '\u043d'
+  shift: '\u041d'
+  capslock: '\u041d'
+  capslock+shift: '\u043d'
+}
+
+key M {
+  label: '\u043c'
+  base: '\u043c'
+  shift: '\u041c'
+  capslock: '\u041c'
+  capslock+shift: '\u043c'
+}
+
+key COMMA {
+  label: '\u002c'
+  base: '\u002c'
+  shift: '\u003c'
+  capslock+shift: '\u003c'
+}
+
+key PERIOD {
+  label: '\u002e'
+  base: '\u002e'
+  shift: '\u003e'
+  capslock+shift: '\u003e'
+}
+
+key SLASH {
+  label: '\u002f'
+  base: '\u002f'
+  shift: '\u003f'
+  capslock+shift: '\u003f'
+}
+
+key SPACE {
+  label: '\u0020'
+  base: '\u0020'
+  shift: '\u0020'
+  capslock+shift: '\u0020'
+}
+
+key PLUS {
+  label: '\u005c'
+  base: '\u005c'
+  shift: '\u007c'
+  capslock+shift: '\u007c'
+}
+
+key NUMPAD_COMMA {
+  label: '\u002c'
+  base: '\u002c'
+  shift: '\u002c'
+  capslock+shift: '\u002c'
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
 	<string name="keyboard_layout_jawi_phonetic_qwerty">Jawi Phonetic (QWERTY)</string>
 	<string name="keyboard_layout_slovak_qwertz">Slovak QWERTZ</string>
 	<string name="keyboard_layout_russian_phonetic_yawert_winrus_com">Russian Phonetic YaWert - WinRus.com</string>
+	<string name="keyboard_layout_russian_phonetic_linux">Russian Phonetic - Linux</string>
 	<string name="keyboard_layout_thai_tis_820_2538">Thai TIS 820-2538</string>
 	<string name="keyboard_layout_abc">ABC - Latin, alphabetical order</string>
 	<string name="keyboard_layout_colemak">Colemak</string>

--- a/app/src/main/res/xml/keyboard_layouts.xml
+++ b/app/src/main/res/xml/keyboard_layouts.xml
@@ -131,6 +131,7 @@
     <keyboard-layout android:label="@string/keyboard_layout_jawi_phonetic_qwerty" android:name="keyboard_layout_jawi_phonetic_qwerty" android:keyboardLayout="@raw/keyboard_layout_jawi_phonetic_qwerty"/>
     <keyboard-layout android:label="@string/keyboard_layout_slovak_qwertz" android:name="keyboard_layout_slovak_qwertz" android:keyboardLayout="@raw/keyboard_layout_slovak_qwertz"/>
     <keyboard-layout android:label="@string/keyboard_layout_russian_phonetic_yawert_winrus_com" android:name="keyboard_layout_russian_phonetic_yawert_winrus_com" android:keyboardLayout="@raw/keyboard_layout_russian_phonetic_yawert_winrus_com"/>
+    <keyboard-layout android:label="@string/keyboard_layout_russian_phonetic_linux" android:name="keyboard_layout_russian_phonetic_linux" android:keyboardLayout="@raw/keyboard_layout_russian_phonetic_linux"/>
     <keyboard-layout android:label="@string/keyboard_layout_thai_tis_820_2538" android:name="keyboard_layout_thai_tis_820_2538" android:keyboardLayout="@raw/keyboard_layout_thai_tis_820_2538"/>
     <keyboard-layout android:label="@string/keyboard_layout_abc" android:name="keyboard_layout_abc" android:keyboardLayout="@raw/keyboard_layout_abc"/>
     <keyboard-layout android:label="@string/keyboard_layout_colemak" android:name="keyboard_layout_colemak" android:keyboardLayout="@raw/keyboard_layout_colemak"/>


### PR DESCRIPTION
This is the standard "Russian (phonetic)" layout from Linux.
Hi, I'm using the same keyboard between my PC, laptop and Android phone so having the same layout makes a lot of sense.
While the Yawert layout in this project is usable, it requires constant mental gymnastics when switching from PC to phone and back, so I've decided to contribute.
This is untested, unfortunately, I've never been anywhere near android development, I tried to build it using standard Github actions, but there was no apk at the end, so I don't know to test it.

Further, if this gets accepted I'll also fix the Georgian layout, currently, it is problematic and certain letters cannot be typed, while others need workarounds.